### PR TITLE
Create manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "iZone",
+  "name": "iZone AC",
+  "documentation": "https://github.com/Swamp-Ig/izone_custom_component/",
+  "dependencies": [],
+  "codeowners": [],
+  "requirements": ["python-izone==1.1.0"]
+}


### PR DESCRIPTION
Integration fails to load in HAS 0.94.3 without the requirements in the manifest

Fixes error 
ERROR (MainThread) [homeassistant.config_entries] Error importing integration izone to set up izone config entry: No module named 'custom_components.izone.config_flow'
